### PR TITLE
Relax version constraints

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,7 +9,7 @@ repository = { type = "github", user = "schurhammer", repo = "gleamy_structures"
 links = [{ title = "Website", href = "https://github.com/schurhammer/gleamy_structures" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.29.0"
+gleam_stdlib = "~> 0.29"
 
 [dev-dependencies]
-gleeunit = "~> 0.10.1"
+gleeunit = "~> 0.10"


### PR DESCRIPTION
Hello!

The previous constraints meant that only gleam_stdlib v0.29.x could be used, which practically meant one could not add this package to a Gleam project./

Thanks,
Louis